### PR TITLE
docs: use correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All you need to do is [register](https://developer.musixmatch.com/signup) in ord
 With your key in hand, it's time to authenticate, so run:
 
 ```python
->>> from musixmatch import Musixmatch
+>>> from pymusixmatch import Musixmatch
 
 >>> musixmatch = Musixmatch('<apikey>')
 ```


### PR DESCRIPTION
this patch updates package name in the README.md according to the changes made in a78b11c4f44b726cfec94d99e698f0c3a8d1651a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated usage example in the README to use the correct module name, ensuring consistency with installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->